### PR TITLE
Allow raw download of .zip

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
     "contentRootPath": "./content",
     "markdownFileExtensions": [".md", ".markdown"],
-    "nativeRenderFileExtensions": [".pdf", ".png", ".img", ".tgz"],
+    "nativeRenderFileExtensions": [".pdf", ".png", ".img", ".tgz", ".zip"],
     "codeRenderMimeTypes": ["text/plain"]
 }


### PR DESCRIPTION
Some additional supplies are in zip format because it's more convenient for students.